### PR TITLE
Failed attempts to fix lib/innshellvars: No such file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ COPY --chown=news:news etc/* etc/
 COPY --chown=news:news etc/* etc/news/
 COPY --chown=news:news etc/inn.conf .
 COPY --chown=news:news db/* db/
+COPY --chown=news:news lib/* lib/
 
 RUN apt-get update -qq && \
   apt-get install --yes tini && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --chown=news:news etc/* etc/
 COPY --chown=news:news etc/* etc/news/
 COPY --chown=news:news etc/inn.conf .
 COPY --chown=news:news db/* db/
-COPY --chown=news:news lib/* lib/
+# COPY --chown=news:news lib/* lib/
 
 RUN apt-get update -qq && \
   apt-get install --yes tini && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,34 @@
 # TODO: Multistage build
 FROM debian:bookworm
 ENV DEBIAN_FRONTEND=noninteractive
-RUN mkdir -p /etc/news/
-COPY etc/inn.conf /etc/news/
-COPY etc/inn.conf /etc/
-
-RUN apt-get update -qq && \
-  apt-get install --yes \
-    bison \
-    curl \
-    openssl \
-    perl \
-    readline-common \
-    tar \ 
-    tini
-RUN apt-get -o Dpkg::Options::=--force-confold install -y inn2
+# RUN mkdir -p /etc/news/
+# COPY etc/inn.conf /etc/news/
+# COPY etc/inn.conf /etc/
 
 # ENV PERL_MM_USE_DEFAULT=1
 # RUN cpan -T GD MIME::Parser
 
+# RUN echo "localhost.localdomain" > /etc/hostname
+# sudo mv hostname /etc/
+# cat /etc/hostname
+
 RUN usermod -d /usr/local/news news
+RUN usermod -d /usr/local/news/etc/news news
 
 WORKDIR /usr/local/news
 COPY --chown=news:news etc/* etc/
+COPY --chown=news:news etc/* etc/news/
+COPY --chown=news:news etc/inn.conf .
 COPY --chown=news:news db/* db/
+
+RUN apt-get update -qq && \
+  apt-get install --yes tini && \
+  apt-get -o Dpkg::Options::=--force-confold install --yes inn2
+
+#  mkdir -p /usr/local/news/etc/news && \
+#  cp /usr/local/news/etc/inn.conf /usr/local/news/etc/news/ && \
+#  ls -laR /usr/local/news/etc && \
+#  apt-get -o Dpkg::Options::=--force-confold install -y inn2
 
 RUN sed -i 's/#\(tlscapath:\)/\1/' etc/inn.conf && \
     sed -i 's/#\(tlscertfile:\)/\1/' etc/inn.conf && \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,8 @@ if [ ! -f etc/key.pem ]; then
 	openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout etc/key.pem -out etc/cert.pem -subj "/CN=news.localhost"
 fi
 
+ls -la
+ls -la lib
 . lib/innshellvars
 
 # Support for implicit TLS

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,0 +1,1 @@
+Placeholder


### PR DESCRIPTION
## Do not merge.

Need to copy `etc/conf.inn` in the right directory before doing `apt-get install --yes inn2` or it will fail with:
> #13 14.89 Setting up inn2 (2.7.1-1+deb12u1) ...
#13 14.97 innconfval: hostname does not resolve or domain not set in inn.conf
#13 14.97 innconfval: the FQDN of the server contains invalid characters not suitable for Message-IDs
#13 14.97 dpkg: error processing package inn2 (--configure):
#13 14.97  installed inn2 package post-installation script subprocess returned error exit status 1

The current `Dockerfile` gets `inn2` installed but then on `docker run --rm -t -p119:119 -p563:563 inn` fails with:
* #3 