### PR TITLE
Working except for SSL

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,9 +5,7 @@ if [ ! -f etc/key.pem ]; then
 	openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout etc/key.pem -out etc/cert.pem -subj "/CN=news.localhost"
 fi
 
-ls -la
-ls -ls /lib
-. lib/innshellvars
+. lib/news/innshellvars
 
 # Support for implicit TLS
 nnrpd -D -p 563 -S


### PR DESCRIPTION
(.venv) ➜  pynntp git:(main) ✗ `pytest`
```
============================= test session starts ==============================
platform darwin -- Python 3.12.6, pytest-8.3.3, pluggy-1.5.0
rootdir: /Users/cclauss/Python/itinerant_futurizer/pynntp
configfile: pyproject.toml
collected 54 items

tests/integration/inn2/test_inn2.py ..xx.FF..x.....x                     [ 29%]
tests/test_headerdict.py ..........                                      [ 48%]
tests/test_utils.py ..xxx...xxx....xxx.....x..                           [ 96%]
tests/test_yenc.py ..                                                    [100%]

=================================== FAILURES ===================================
[ ... ]
=========================== short test summary info ============================
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client_with_ssl - ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1000)
FAILED tests/integration/inn2/test_inn2.py::test_nntp_client_with_ssl_starttls - nntp.nntp.NNTPPermanentError: 580 Error initializing TLS
=================== 2 failed, 38 passed, 14 xfailed in 0.55s ===================
```